### PR TITLE
fix(ui/textfield): unfocus on tap outside.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -188,6 +188,9 @@ class _MyAppState extends State<MyApp> {
                 TextField(
                   // peers address
                   controller: textEditController,
+                  onTapOutside: (event) => {
+                    FocusManager.instance.primaryFocus?.unfocus(),
+                  },
                   minLines: 1,
                   maxLines: null,
                   keyboardType: TextInputType.multiline,


### PR DESCRIPTION
Unfocus TextField when user tap outside the textfield, so the keyboard can be closed

It is to fix #53 

cc @khaledyoussef24 